### PR TITLE
Read hex files with 45 bytes per scan

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ History
 Bug Fixes
 ~~~~~~~~~
 * Fix bug in pressure conversion, was missing subtraction of atmospheric pressure.
+* Enable reading hex files with 48 bytes per scan. Fixes :issue:`11`.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Bug Fixes
 ~~~~~~~~~
 * Fix bug in pressure conversion, was missing subtraction of atmospheric pressure.
 * Enable reading hex files with 48 bytes per scan. Fixes :issue:`11`.
+* Enable reading hex files with 45 bytes per scan. Fixes :issue:`14`.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/ctdproc/io.py
+++ b/ctdproc/io.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
+import errno
+import os
 from pathlib import Path
 
 import numpy as np
@@ -52,9 +54,18 @@ class CTD(object):
         self.parse_hex()
         self.physicalunits()
 
-    def _detect_missing_word(self):
-        """Sometimes there is no SPAR sensor, in this case one hex word may be missing.
-        It lives on voltage channel 9.
+    def _detect_missing_words(self):
+        """
+        Determine location of data entries in hex file line.
+
+        Sometimes there is no SPAR sensor, in this case one hex word may
+        be missing. It lives on voltage channel 9.
+
+        Locating the right data entries also depends on the number of
+        bytes written per scan. We read this information from the
+        header.
+
+        For details, see p.67 in manual-11pV2_018.pdf
         """
         if ~hasattr(self, "cfgp"):
             self.read_xml_config()
@@ -65,8 +76,9 @@ class CTD(object):
             self._hexoffset = -6
         else:
             self._hexoffset = 0
-        # self._extra_hexoffset = 0
         if "14" in self.cfgp.loc["@index"].values and self._bytes_per_scan == 48:
+            self._extra_hexoffset = 8
+        elif "14" not in self.cfgp.loc["@index"].values and self._bytes_per_scan == 45:
             self._extra_hexoffset = 8
         else:
             self._extra_hexoffset = 0
@@ -102,7 +114,7 @@ class CTD(object):
                         self._bytes_per_scan = int(l[i + 2 :])
                 else:
                     break
-            self._detect_missing_word()
+            self._detect_missing_words()
             # read data
             for l in fin:
                 # parse frequency channels
@@ -362,13 +374,20 @@ class CTD(object):
         name = pp.stem
         xmlfile = name.upper() + ".XMLCON"
         p = pp.parent
-        self.xmlfile = p.joinpath(xmlfile)
+        if p.joinpath(xmlfile).exists():
+            self.xmlfile = p.joinpath(xmlfile)
+        else:
+            xmlfile = name.upper() + ".XMLCON"
+            self.xmlfile = p.joinpath(xmlfile)
 
     def read_xml_config(self):
         """Read xml config file."""
         self._find_xmlconfig()
-        with open(self.xmlfile) as fd:
-            tmp = xmltodict.parse(fd.read())
+        try:
+            with open(self.xmlfile) as fd:
+                tmp = xmltodict.parse(fd.read())
+        except OSError as e:
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), e.filename)
         tmp = tmp["SBE_InstrumentConfiguration"]
         tmp = tmp["Instrument"]
         sa = tmp["SensorArray"]["Sensor"]

--- a/ctdproc/io.py
+++ b/ctdproc/io.py
@@ -372,12 +372,14 @@ class CTD(object):
         Config file needs to be in the same directory as the hex file."""
         pp = Path(self.filename)
         name = pp.stem
+        # try upper case filename
         xmlfile = name.upper() + ".XMLCON"
         p = pp.parent
-        if p.joinpath(xmlfile).exists():
-            self.xmlfile = p.joinpath(xmlfile)
-        else:
-            xmlfile = name.upper() + ".XMLCON"
+        self.xmlfile = p.joinpath(xmlfile)
+        # use os.listdir to find the actual case of the filename if the upper
+        # case did not work.
+        if self.xmlfile not in os.listdir(os.path.dirname(self.xmlfile)):
+            xmlfile = name.lower() + ".XMLCON"
             self.xmlfile = p.joinpath(xmlfile)
 
     def read_xml_config(self):

--- a/ctdproc/io.py
+++ b/ctdproc/io.py
@@ -378,7 +378,7 @@ class CTD(object):
         self.xmlfile = p.joinpath(xmlfile)
         # use os.listdir to find the actual case of the filename if the upper
         # case did not work.
-        if self.xmlfile not in os.listdir(os.path.dirname(self.xmlfile)):
+        if self.xmlfile.name not in os.listdir(os.path.dirname(self.xmlfile)):
             xmlfile = name.lower() + ".XMLCON"
             self.xmlfile = p.joinpath(xmlfile)
 

--- a/ctdproc/tests/data/lajit2-sr1614-001.XMLCON
+++ b/ctdproc/tests/data/lajit2-sr1614-001.XMLCON
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SBE_InstrumentConfiguration SB_ConfigCTD_FileVersion="7.26.1.0" >
+  <Instrument Type="8" >
+    <Name>SBE 911plus/917plus CTD</Name>
+    <FrequencyChannelsSuppressed>0</FrequencyChannelsSuppressed>
+    <VoltageWordsSuppressed>0</VoltageWordsSuppressed>
+    <ComputerInterface>0</ComputerInterface>
+    <!-- 0 == SBE11plus Firmware Version >= 5.0 -->
+    <!-- 1 == SBE11plus Firmware Version < 5.0 -->
+    <!-- 2 == SBE 17plus SEARAM -->
+    <!-- 3 == None -->
+    <DeckUnitVersion>0</DeckUnitVersion>
+    <ScansToAverage>1</ScansToAverage>
+    <SurfaceParVoltageAdded>0</SurfaceParVoltageAdded>
+    <ScanTimeAdded>1</ScanTimeAdded>
+    <NmeaPositionDataAdded>1</NmeaPositionDataAdded>
+    <NmeaDepthDataAdded>0</NmeaDepthDataAdded>
+    <NmeaTimeAdded>1</NmeaTimeAdded>
+    <NmeaDeviceConnectedToPC>1</NmeaDeviceConnectedToPC>
+    <SensorArray Size="13" >
+      <Sensor index="0" SensorID="55" >
+        <TemperatureSensor SensorID="55" >
+          <SerialNumber>6049</SerialNumber>
+          <CalibrationDate>18-Feb-2016 </CalibrationDate>
+          <UseG_J>1</UseG_J>
+          <A>4.35592085e-003</A>
+          <B>6.38746689e-004</B>
+          <C>2.13124279e-005</C>
+          <D>1.84766894e-006</D>
+          <F0_Old>1000.000</F0_Old>
+          <G>4.31232005e-003</G>
+          <H>6.26607142e-004</H>
+          <I>1.94547342e-005</I>
+          <J>1.44557637e-006</J>
+          <F0>1000.000</F0>
+          <Slope>1.00000000</Slope>
+          <Offset>0.0000</Offset>
+        </TemperatureSensor>
+      </Sensor>
+      <Sensor index="1" SensorID="3" >
+        <ConductivitySensor SensorID="3" >
+          <SerialNumber>4537</SerialNumber>
+          <CalibrationDate>26 Apr 16</CalibrationDate>
+          <UseG_J>1</UseG_J>
+          <!-- Cell const and series R are applicable only for wide range sensors. -->
+          <SeriesR>0.0000</SeriesR>
+          <CellConst>2000.0000</CellConst>
+          <ConductivityType>0</ConductivityType>
+          <Coefficients equation="0" >
+            <A>0.00000000e+000</A>
+            <B>0.00000000e+000</B>
+            <C>0.00000000e+000</C>
+            <D>0.00000000e+000</D>
+            <M>0.0</M>
+            <CPcor>-9.57000000e-008</CPcor>
+          </Coefficients>
+          <Coefficients equation="1" >
+            <G>-9.81163193e+000</G>
+            <H>1.38141589e+000</H>
+            <I>-1.14496312e-003</I>
+            <J>1.47570081e-004</J>
+            <CPcor>-9.57000000e-008</CPcor>
+            <CTcor>3.2500e-006</CTcor>
+            <!-- WBOTC not applicable unless ConductivityType = 1. -->
+            <WBOTC>0.00000000e+000</WBOTC>
+          </Coefficients>
+          <Slope>1.00000000</Slope>
+          <Offset>0.00000</Offset>
+        </ConductivitySensor>
+      </Sensor>
+      <Sensor index="2" SensorID="45" >
+        <PressureSensor SensorID="45" >
+          <SerialNumber>1282</SerialNumber>
+          <CalibrationDate>19-May-2016</CalibrationDate>
+          <C1>-4.704315e+004</C1>
+          <C2>-7.802703e-001</C2>
+          <C3>1.407900e-002</C3>
+          <D1>3.535600e-002</D1>
+          <D2>0.000000e+000</D2>
+          <T1>2.992986e+001</T1>
+          <T2>-5.128990e-004</T2>
+          <T3>3.850000e-006</T3>
+          <T4>2.299290e-009</T4>
+          <Slope>1.00000000</Slope>
+          <Offset>0.00000</Offset>
+          <T5>0.000000e+000</T5>
+          <AD590M>1.279800e-002</AD590M>
+          <AD590B>-9.109960e+000</AD590B>
+        </PressureSensor>
+      </Sensor>
+      <Sensor index="3" SensorID="55" >
+        <TemperatureSensor SensorID="55" >
+          <SerialNumber>6140</SerialNumber>
+          <CalibrationDate>05 May 16</CalibrationDate>
+          <UseG_J>1</UseG_J>
+          <A>4.34252126e-003</A>
+          <B>6.36806473e-004</B>
+          <C>2.12985541e-005</C>
+          <D>1.84191818e-006</D>
+          <F0_Old>1000.000</F0_Old>
+          <G>4.31716173e-003</G>
+          <H>6.36011362e-004</H>
+          <I>2.17119667e-005</I>
+          <J>2.02176265e-006</J>
+          <F0>1000.000</F0>
+          <Slope>1.00000000</Slope>
+          <Offset>0.0000</Offset>
+        </TemperatureSensor>
+      </Sensor>
+      <Sensor index="4" SensorID="3" >
+        <ConductivitySensor SensorID="3" >
+          <SerialNumber>4539</SerialNumber>
+          <CalibrationDate>26 Apr 16</CalibrationDate>
+          <UseG_J>1</UseG_J>
+          <!-- Cell const and series R are applicable only for wide range sensors. -->
+          <SeriesR>0.0000</SeriesR>
+          <CellConst>2000.0000</CellConst>
+          <ConductivityType>0</ConductivityType>
+          <Coefficients equation="0" >
+            <A>0.00000000e+000</A>
+            <B>0.00000000e+000</B>
+            <C>0.00000000e+000</C>
+            <D>0.00000000e+000</D>
+            <M>0.0</M>
+            <CPcor>-9.57000000e-008</CPcor>
+          </Coefficients>
+          <Coefficients equation="1" >
+            <G>-9.84085141e+000</G>
+            <H>1.44743498e+000</H>
+            <I>-3.09632278e-004</I>
+            <J>9.37208509e-005</J>
+            <CPcor>-9.57000000e-008</CPcor>
+            <CTcor>3.2500e-006</CTcor>
+            <!-- WBOTC not applicable unless ConductivityType = 1. -->
+            <WBOTC>0.00000000e+000</WBOTC>
+          </Coefficients>
+          <Slope>1.00000000</Slope>
+          <Offset>0.00000</Offset>
+        </ConductivitySensor>
+      </Sensor>
+      <Sensor index="5" SensorID="20" >
+        <FluoroWetlabECO_AFL_FL_Sensor SensorID="20" >
+          <SerialNumber>FLRTD 4334</SerialNumber>
+          <CalibrationDate>4/6/2016</CalibrationDate>
+          <ScaleFactor>2.50000000e+001</ScaleFactor>
+          <!-- Dark output -->
+          <Vblank>0.0150</Vblank>
+        </FluoroWetlabECO_AFL_FL_Sensor>
+      </Sensor>
+      <Sensor index="6" SensorID="42" >
+        <PAR_BiosphericalLicorChelseaSensor SensorID="42" >
+          <SerialNumber>QSP235070629</SerialNumber>
+          <CalibrationDate>05/05/16</CalibrationDate>
+          <M>1.00000000</M>
+          <B>0.00000000</B>
+          <CalibrationConstant>19801980198.01979800</CalibrationConstant>
+          <Multiplier>1.00000000</Multiplier>
+          <Offset>-0.05140000</Offset>
+        </PAR_BiosphericalLicorChelseaSensor>
+      </Sensor>
+      <Sensor index="7" SensorID="71" >
+        <WET_LabsCStar SensorID="71" >
+          <SerialNumber>CST-493DR</SerialNumber>
+          <CalibrationDate>03/04/16</CalibrationDate>
+          <M>23.0625</M>
+          <B>-1.5683</B>
+          <PathLength>0.250</PathLength>
+        </WET_LabsCStar>
+      </Sensor>
+      <Sensor index="8" SensorID="27" >
+        <NotInUse SensorID="27" >
+          <SerialNumber></SerialNumber>
+          <CalibrationDate></CalibrationDate>
+          <OutputType>2</OutputType>
+          <Free>1</Free>
+        </NotInUse>
+      </Sensor>
+      <Sensor index="9" SensorID="0" >
+        <AltimeterSensor SensorID="0" >
+          <SerialNumber>VA-500</SerialNumber>
+          <CalibrationDate>1 Jan 2016</CalibrationDate>
+          <ScaleFactor>15.000</ScaleFactor>
+          <Offset>0.000</Offset>
+        </AltimeterSensor>
+      </Sensor>
+      <Sensor index="10" SensorID="27" >
+        <NotInUse SensorID="27" >
+          <SerialNumber></SerialNumber>
+          <CalibrationDate></CalibrationDate>
+          <OutputType>2</OutputType>
+          <Free>1</Free>
+        </NotInUse>
+      </Sensor>
+      <Sensor index="11" SensorID="38" >
+        <OxygenSensor SensorID="38" >
+          <SerialNumber>3357</SerialNumber>
+          <CalibrationDate>06 May 16</CalibrationDate>
+          <Use2007Equation>1</Use2007Equation>
+          <CalibrationCoefficients equation="0" >
+            <!-- Coefficients for Owens-Millard equation. -->
+            <Boc>0.0000</Boc>
+            <Soc>0.0000e+000</Soc>
+            <offset>0.0000</offset>
+            <Pcor>0.00e+000</Pcor>
+            <Tcor>0.0000</Tcor>
+            <Tau>0.0</Tau>
+          </CalibrationCoefficients>
+          <CalibrationCoefficients equation="1" >
+            <!-- Coefficients for Sea-Bird equation - SBE calibration in 2007 and later. -->
+            <Soc>5.4880e-001</Soc>
+            <offset>-0.4977</offset>
+            <A>-3.9840e-003</A>
+            <B> 1.5969e-004</B>
+            <C>-2.8295e-006</C>
+            <D0> 2.5826e+000</D0>
+            <D1> 1.92634e-004</D1>
+            <D2>-4.64803e-002</D2>
+            <E> 3.6000e-002</E>
+            <Tau20> 1.4900</Tau20>
+            <H1>-3.3000e-002</H1>
+            <H2> 5.0000e+003</H2>
+            <H3> 1.4500e+003</H3>
+          </CalibrationCoefficients>
+        </OxygenSensor>
+      </Sensor>
+      <Sensor index="12" SensorID="27" >
+        <NotInUse SensorID="27" >
+          <SerialNumber></SerialNumber>
+          <CalibrationDate></CalibrationDate>
+          <OutputType>2</OutputType>
+          <Free>1</Free>
+        </NotInUse>
+      </Sensor>
+    </SensorArray>
+  </Instrument>
+</SBE_InstrumentConfiguration>

--- a/ctdproc/tests/test_basic.py
+++ b/ctdproc/tests/test_basic.py
@@ -25,3 +25,15 @@ def test_read_hex(rootdir, tmpdir):
     cx.to_netcdf(p)
     cx2 = xr.open_dataset(p)
     assert type(cx2) == xr.core.dataset.Dataset
+
+
+def test_read_lajit(rootdir, tmpdir):
+    """Read test data from La Jolla Canyon."""
+    hexfile = rootdir / "data/lajit2-sr1614-001.hex"
+    assert type(hexfile) == pathlib.PosixPath
+    print(hexfile)
+    assert hexfile.exists()
+    c = ctd.io.CTD(hexfile)
+
+    cx = c.to_xarray()
+    assert type(cx) == xr.core.dataset.Dataset


### PR DESCRIPTION
Fixes #14 .
* Also throw an error if xmlcon file cannot be found.
* Add change to history.
* Add a test for reading 45 byter per scan, including data file