### PR TITLE
copy dict to avoid key deletion error

### DIFF
--- a/ctdproc/io.py
+++ b/ctdproc/io.py
@@ -453,7 +453,7 @@ class CTDHex(object):
                         kstr = "{}{}".format(k, ci)
                     else:
                         kstr = k
-                    cfg[kstr] = si
+                    cfg[kstr] = si.copy()
                     cfg[kstr]["cal"] = munchify(cfg[kstr][k])
                     del cfg[kstr][k]
         self.cfgp = pd.DataFrame(cfg)


### PR DESCRIPTION
Explicitly copy dictionary to avoid errors related to key deletion. 