### PR TITLE
Refactoring ctdproc.proc.remove_out_of_bounds()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,9 @@ Breaking Changes
 Bug Fixes
 ~~~~~~~~~
 * Fix byte offset for reading hex file on R/V Armstrong (cruise AR73 May 2023). (:pull:`26`)
+* Fix bug in `ctdproc.proc.remove_out_of_bounds()` for python > 3.8. (:pull:`29`)
+    By `Øyvind Lundesgaard  <https://github.com/oyvlun>`_.
+
 
 .. Documentation
 .. ~~~~~~~~~~~~~

--- a/ctdproc/proc.py
+++ b/ctdproc/proc.py
@@ -197,15 +197,8 @@ def despike(da, spike_threshold):
 
 def remove_out_of_bounds(da, bmin, bmax):
     """Remove out of bounds data."""
-    ib = np.squeeze(
-        np.where(
-            (
-                (np.greater(da, bmax, where=np.isfinite(da)))
-                | (np.less(da, bmin, where=np.isfinite(da)))
-            )
-        )
-    )
-    da[ib] = np.nan
+    
+    da = da.where((da<=bmax) & (da>=bmin))
 
     return da
 


### PR DESCRIPTION
Refactored ``ctdproc.proc.remove_out_of_bounds``, replacing the numpy approach with using ``xarray.where()``.

Simplifies the code, but more importantly the present version throws an error in python >3.8 (tested in 3.11).

The problem seems to be that ``da`` is an xr.Dataset  -> ``np.isfinite(da)`` is an xr.Dataset, and 
it looks like the ``where`` argument (in this case ``np.isfinite(da)``)  to ``np.greater`` and ``np.less`` can't be an xr.Dataset.

More generally, I think there is room for simplifying more of ``ctdproc.proc`` in the same way, perhaps making for clearer code. Happy to contribute there if others agree.

Note: I am only just getting familiar with contributing to github projects - feel free to let me know if I'm not in accordance with contributor guidelines (for example, are tiny PRs like this one ok?) :)

<details><summary> Output when calling *ctd.proc.run_all(cx)* in a test dataset in Python 3.11 </summary>

::
    
```

  RecursionError                            Traceback (most recent call last)
  Cell In[13], line 1
  ----> 1 cx_ud = ctd.proc.run_all(cx)

  File ~/work/code/python/ctdproc/ctdproc/proc.py:47, in run_all(ds)
      45     d = calcs.swcalcs(d)
      46     d = rmloops(d)
  ---> 47     d = cleanup_ud(d)
      48     ds_updown[v] = d
      50 return ds_updown

  File ~/work/code/python/ctdproc/ctdproc/proc.py:170, in cleanup_ud(ds)
      168     ds[v] = despike(ds[v], ds.attrs["spike_thresh_s"])
      169     # remove out of bounds data
  --> 170     ds[v] = remove_out_of_bounds(
      171         ds[v], bmin=ds.attrs["bounds_s"][0], bmax=ds.attrs["bounds_s"][1]
      172     )
      173     ds[v].data = helpers.glitchcorrect(
      174         ds[v], ds.attrs["diff_s"], ds.attrs["prod_s"], ibefore, iafter
      175     )
      177 # calculate potential/conservative temperature, potential density anomaly

  File ~/work/code/python/ctdproc/ctdproc/proc.py:204, in remove_out_of_bounds(da, bmin, bmax)
      199 """Remove out of bounds data."""
      200 print(da, np.isfinite(da))
      201 ib = np.squeeze(
      202     np.where(
      203         (
  --> 204             (np.greater(da, bmax, where=np.isfinite(da)))
      205             | (np.less(da, bmin, where=np.isfinite(da)))
      206         )
      207     )
      208 )
      209 da[ib] = np.nan
      211 return da

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/arithmetic.py:86, in SupportsArithmetic.__array_ufunc__(self, ufunc, method, *inputs, **kwargs)
      77     raise NotImplementedError(
      78         "xarray objects are not yet supported in the `out` argument "
      79         "for ufuncs. As an alternative, consider explicitly "
      80         "converting xarray objects to NumPy arrays (e.g., with "
      81         "`.values`)."
      82     )
      84 join = dataset_join = OPTIONS["arithmetic_join"]
  ---> 86 return apply_ufunc(
      87     ufunc,
      88     *inputs,
      89     input_core_dims=((),) * ufunc.nin,
      90     output_core_dims=((),) * ufunc.nout,
      91     join=join,
      92     dataset_join=dataset_join,
      93     dataset_fill_value=np.nan,
      94     kwargs=kwargs,
      95     dask="allowed",
      96     keep_attrs=_get_keep_attrs(default=True),
      97 )

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:1197, in apply_ufunc(func, input_core_dims, output_core_dims, exclude_dims, vectorize, join, dataset_join, dataset_fill_value, keep_attrs, kwargs, dask, output_dtypes, output_sizes, meta, dask_gufunc_kwargs, *args)
    1195 # feed DataArray apply_variable_ufunc through apply_dataarray_vfunc
    1196 elif any(isinstance(a, DataArray) for a in args):
  -> 1197     return apply_dataarray_vfunc(
    1198         variables_vfunc,
    1199         *args,
    1200         signature=signature,
    1201         join=join,
    1202         exclude_dims=exclude_dims,
    1203         keep_attrs=keep_attrs,
    1204     )
    1205 # feed Variables directly through apply_variable_ufunc
    1206 elif any(isinstance(a, Variable) for a in args):

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:304, in apply_dataarray_vfunc(func, signature, join, exclude_dims, keep_attrs, *args)
      299 result_coords, result_indexes = build_output_coords_and_indexes(
      300     args, signature, exclude_dims, combine_attrs=keep_attrs
      301 )
      303 data_vars = [getattr(a, "variable", a) for a in args]
  --> 304 result_var = func(*data_vars)
      306 out: tuple[DataArray, ...] | DataArray
      307 if signature.num_outputs > 1:

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:761, in apply_variable_ufunc(func, signature, exclude_dims, dask, output_dtypes, vectorize, keep_attrs, dask_gufunc_kwargs, *args)
      756     if vectorize:
      757         func = _vectorize(
      758             func, signature, output_dtypes=output_dtypes, exclude_dims=exclude_dims
      759         )
  --> 761 result_data = func(*input_data)
      763 if signature.num_outputs == 1:
      764     result_data = (result_data,)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/arithmetic.py:86, in SupportsArithmetic.__array_ufunc__(self, ufunc, method, *inputs, **kwargs)
      77     raise NotImplementedError(
      78         "xarray objects are not yet supported in the `out` argument "
      79         "for ufuncs. As an alternative, consider explicitly "
      80         "converting xarray objects to NumPy arrays (e.g., with "
      81         "`.values`)."
      82     )
      84 join = dataset_join = OPTIONS["arithmetic_join"]
  ---> 86 return apply_ufunc(
      87     ufunc,
      88     *inputs,
      89     input_core_dims=((),) * ufunc.nin,
      90     output_core_dims=((),) * ufunc.nout,
      91     join=join,
      92     dataset_join=dataset_join,
      93     dataset_fill_value=np.nan,
      94     kwargs=kwargs,
      95     dask="allowed",
      96     keep_attrs=_get_keep_attrs(default=True),
      97 )

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:1210, in apply_ufunc(func, input_core_dims, output_core_dims, exclude_dims, vectorize, join, dataset_join, dataset_fill_value, keep_attrs, kwargs, dask, output_dtypes, output_sizes, meta, dask_gufunc_kwargs, *args)
    1207     return variables_vfunc(*args)
    1208 else:
    1209     # feed anything else through apply_array_ufunc
  -> 1210     return apply_array_ufunc(func, *args, dask=dask)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:833, in apply_array_ufunc(func, dask, *args)
      831     else:
      832         raise ValueError(f"unknown setting for dask array handling: {dask}")
  --> 833 return func(*args)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/arithmetic.py:86, in SupportsArithmetic.__array_ufunc__(self, ufunc, method, *inputs, **kwargs)
      77     raise NotImplementedError(
      78         "xarray objects are not yet supported in the `out` argument "
      79         "for ufuncs. As an alternative, consider explicitly "
      80         "converting xarray objects to NumPy arrays (e.g., with "
      81         "`.values`)."
      82     )
      84 join = dataset_join = OPTIONS["arithmetic_join"]
  ---> 86 return apply_ufunc(
      87     ufunc,
      88     *inputs,
      89     input_core_dims=((),) * ufunc.nin,
      90     output_core_dims=((),) * ufunc.nout,
      91     join=join,
      92     dataset_join=dataset_join,
      93     dataset_fill_value=np.nan,
      94     kwargs=kwargs,
      95     dask="allowed",
      96     keep_attrs=_get_keep_attrs(default=True),
      97 )

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:1210, in apply_ufunc(func, input_core_dims, output_core_dims, exclude_dims, vectorize, join, dataset_join, dataset_fill_value, keep_attrs, kwargs, dask, output_dtypes, output_sizes, meta, dask_gufunc_kwargs, *args)
    1207     return variables_vfunc(*args)
    1208 else:
    1209     # feed anything else through apply_array_ufunc
  -> 1210     return apply_array_ufunc(func, *args, dask=dask)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:833, in apply_array_ufunc(func, dask, *args)
      831     else:
      832         raise ValueError(f"unknown setting for dask array handling: {dask}")
  --> 833 return func(*args)

      [... skipping similar frames: SupportsArithmetic.__array_ufunc__ at line 86 (736 times), apply_ufunc at line 1210 (736 times), apply_array_ufunc at line 833 (735 times)]

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:833, in apply_array_ufunc(func, dask, *args)
      831     else:
      832         raise ValueError(f"unknown setting for dask array handling: {dask}")
  --> 833 return func(*args)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/arithmetic.py:86, in SupportsArithmetic.__array_ufunc__(self, ufunc, method, *inputs, **kwargs)
      77     raise NotImplementedError(
      78         "xarray objects are not yet supported in the `out` argument "
      79         "for ufuncs. As an alternative, consider explicitly "
      80         "converting xarray objects to NumPy arrays (e.g., with "
      81         "`.values`)."
      82     )
      84 join = dataset_join = OPTIONS["arithmetic_join"]
  ---> 86 return apply_ufunc(
      87     ufunc,
      88     *inputs,
      89     input_core_dims=((),) * ufunc.nin,
      90     output_core_dims=((),) * ufunc.nout,
      91     join=join,
      92     dataset_join=dataset_join,
      93     dataset_fill_value=np.nan,
      94     kwargs=kwargs,
      95     dask="allowed",
      96     keep_attrs=_get_keep_attrs(default=True),
      97 )

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:1210, in apply_ufunc(func, input_core_dims, output_core_dims, exclude_dims, vectorize, join, dataset_join, dataset_fill_value, keep_attrs, kwargs, dask, output_dtypes, output_sizes, meta, dask_gufunc_kwargs, *args)
    1207     return variables_vfunc(*args)
    1208 else:
    1209     # feed anything else through apply_array_ufunc
  -> 1210     return apply_array_ufunc(func, *args, dask=dask)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:815, in apply_array_ufunc(func, dask, *args)
      813 def apply_array_ufunc(func, *args, dask="forbidden"):
      814     """Apply a ndarray level function over ndarray objects."""
  --> 815     if any(is_chunked_array(arg) for arg in args):
      816         if dask == "forbidden":
      817             raise ValueError(
      818                 "apply_ufunc encountered a dask array on an "
      819                 "argument, but handling for dask arrays has not "
    (...)
      822                 "``.load()`` or ``.compute()``"
      823             )

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/computation.py:815, in <genexpr>(.0)
      813 def apply_array_ufunc(func, *args, dask="forbidden"):
      814     """Apply a ndarray level function over ndarray objects."""
  --> 815     if any(is_chunked_array(arg) for arg in args):
      816         if dask == "forbidden":
      817             raise ValueError(
      818                 "apply_ufunc encountered a dask array on an "
      819                 "argument, but handling for dask arrays has not "
    (...)
      822                 "``.load()`` or ``.compute()``"
      823             )

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/pycompat.py:99, in is_chunked_array(x)
      98 def is_chunked_array(x) -> bool:
  ---> 99     return is_duck_dask_array(x) or (is_duck_array(x) and hasattr(x, "chunks"))

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/pycompat.py:95, in is_duck_dask_array(x)
      94 def is_duck_dask_array(x):
  ---> 95     return is_duck_array(x) and is_dask_collection(x)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/pycompat.py:87, in is_dask_collection(x)
      86 def is_dask_collection(x):
  ---> 87     if module_available("dask"):
      88         from dask.base import is_dask_collection
      90         return is_dask_collection(x)

  File ~/mambaforge/envs/ctdproc/lib/python3.11/site-packages/xarray/core/utils.py:1160, in module_available(module)
    1145 def module_available(module: str) -> bool:
    1146     """Checks whether a module is installed without importing it.
    1147 
    1148     Use this for a lightweight check and lazy imports.
    (...)
    1158         Whether the module is installed.
    1159     """
  -> 1160     return importlib.util.find_spec(module) is not None

  File <frozen importlib.util>:103, in find_spec(name, package)

  File <frozen importlib._bootstrap>:1078, in _find_spec(name, path, target)

  File <frozen importlib._bootstrap>:922, in find_spec(cls, fullname, path, target)

  File <frozen importlib._bootstrap>:241, in _call_with_frames_removed(f, *args, **kwds)

  RecursionError: maximum recursion depth exceeded while calling a Python object

```

<\details>