### PR TITLE
Regen docs/requirements.txt; restrict Dependabot to pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,47 +2,47 @@
 #    uv pip compile pyproject.toml --group dev -o docs/requirements.txt
 alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+babel==2.18.0
     # via sphinx
-certifi==2025.10.5
+certifi==2026.4.22
     # via
     #   netcdf4
     #   requests
 cftime==1.6.5
     # via netcdf4
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-docutils==0.21.2
+docutils==0.22.4
     # via
     #   sphinx
     #   sphinx-rtd-theme
-fonttools==4.60.1
+fonttools==4.62.1
     # via matplotlib
-gsw==3.6.20
+gsw==3.6.21
     # via ctdproc (pyproject.toml)
-idna==3.11
+idna==3.13
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
     # via sphinx
-kiwisolver==1.4.9
+kiwisolver==1.5.0
     # via matplotlib
 markupsafe==3.0.3
     # via jinja2
-matplotlib==3.10.7
+matplotlib==3.10.9
     # via ctdproc (pyproject.toml)
 munch==4.0.0
     # via ctdproc (pyproject.toml)
-netcdf4==1.7.3
+netcdf4==1.7.4
     # via ctdproc (pyproject.toml)
-numpy==2.3.4
+numpy==2.4.4
     # via
     #   ctdproc (pyproject.toml)
     #   cftime
@@ -53,55 +53,53 @@ numpy==2.3.4
     #   pandas
     #   scipy
     #   xarray
-packaging==25.0
+packaging==26.2
     # via
     #   matplotlib
     #   pytest
     #   sphinx
     #   xarray
-pandas==2.3.3
+pandas==3.0.2
     # via
     #   ctdproc (pyproject.toml)
     #   xarray
-pillow==12.0.0
+pillow==12.2.0
     # via matplotlib
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   pytest
     #   sphinx
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via matplotlib
-pytest==9.0.0
+pytest==9.0.3
     # via ctdproc (pyproject.toml:dev)
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2025.2
-    # via pandas
-requests==2.32.5
+requests==2.33.1
     # via sphinx
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
-ruff==0.14.4
+ruff==0.15.12
     # via ctdproc (pyproject.toml:dev)
-scipy==1.16.3
+scipy==1.17.1
     # via ctdproc (pyproject.toml)
 six==1.17.0
     # via python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==8.2.3
+sphinx==9.1.0
     # via
     #   ctdproc (pyproject.toml:dev)
     #   sphinx-issues
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-issues==5.0.1
+sphinx-issues==6.0.0
     # via ctdproc (pyproject.toml:dev)
-sphinx-rtd-theme==3.0.2
+sphinx-rtd-theme==3.1.0
     # via ctdproc (pyproject.toml:dev)
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -117,11 +115,9 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tzdata==2025.2
-    # via pandas
-urllib3==2.5.0
+urllib3==2.6.3
     # via requests
-xarray==2025.10.1
+xarray==2026.4.0
     # via ctdproc (pyproject.toml)
-xmltodict==1.0.2
+xmltodict==1.0.4
     # via ctdproc (pyproject.toml)


### PR DESCRIPTION
## Summary

- Regenerate `docs/requirements.txt` via `uv pip compile pyproject.toml --group dev --upgrade -o docs/requirements.txt`. The file is autogenerated (per its own header), so the right way to update it is regen — not hand-patching individual transitive pins.
- This absorbs the bumps proposed in the open Dependabot PRs #51 (fonttools), #53 (urllib3), #54 (pillow), and goes a bit further on fonttools/pillow because newer releases are now available.
- Add `.github/dependabot.yml` declaring a single `pip` ecosystem rooted at `/`, so Dependabot tracks `pyproject.toml` direct deps only and stops opening PRs against `docs/requirements.txt`. Going forward, regenerate the docs lock at release time.

## Test plan

- [ ] ReadTheDocs build succeeds against the new `docs/requirements.txt`
- [ ] After merge, close #51, #53, #54 as superseded